### PR TITLE
Always create history on Canvas startup

### DIFF
--- a/x-pack/plugins/canvas/public/application.tsx
+++ b/x-pack/plugins/canvas/public/application.tsx
@@ -33,7 +33,7 @@ import { CapabilitiesStrings } from '../i18n';
 
 import { startServices, services } from './services';
 // @ts-ignore Untyped local
-import { destroyHistory } from './lib/history_provider';
+import { createHistory, destroyHistory } from './lib/history_provider';
 // @ts-ignore Untyped local
 import { stopRouter } from './lib/router_provider';
 import { initFunctions } from './functions';
@@ -96,6 +96,9 @@ export const initializeCanvas = async (
   for (const fn of canvasFunctions) {
     services.expressions.getService().registerFunction(fn);
   }
+
+  // Re-initialize our history
+  createHistory();
 
   // Create Store
   const canvasStore = await createStore(coreSetup, setupPlugins);

--- a/x-pack/plugins/canvas/public/lib/history_provider.js
+++ b/x-pack/plugins/canvas/public/lib/history_provider.js
@@ -134,7 +134,7 @@ function wrapHistoryInstance(history) {
   return wrappedHistory;
 }
 
-let instances = new WeakMap();
+const instances = new WeakMap();
 
 const getHistoryInstance = (win) => {
   // if no window object, use memory module
@@ -144,13 +144,7 @@ const getHistoryInstance = (win) => {
   return createHashStateHistory();
 };
 
-export const historyProvider = (win = getWindow()) => {
-  // return cached instance if one exists
-  const instance = instances.get(win);
-  if (instance) {
-    return instance;
-  }
-
+export const createHistory = (win = getWindow()) => {
   // create and cache wrapped history instance
   const historyInstance = getHistoryInstance(win);
   const wrappedInstance = wrapHistoryInstance(historyInstance);
@@ -159,12 +153,20 @@ export const historyProvider = (win = getWindow()) => {
   return wrappedInstance;
 };
 
+export const historyProvider = (win = getWindow()) => {
+  // return cached instance if one exists
+  const instance = instances.get(win);
+  if (instance) {
+    return instance;
+  }
+
+  return createHistory(win);
+};
+
 export const destroyHistory = (win = getWindow()) => {
   const instance = instances.get(win);
 
   if (instance) {
     instance.resetOnChange();
   }
-
-  instances = new WeakMap();
 };


### PR DESCRIPTION
This changes makes sure we always are re-creating our wrapped history instance whenever we navigate back to Canvas