### PR TITLE
[Controls] Time slider design improvements

### DIFF
--- a/src/plugins/controls/public/control_types/time_slider/time_slider.component.scss
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider.component.scss
@@ -1,18 +1,28 @@
-.optionsList__anchorOverride {
+.timeSlider__anchorOverride {
   display:block;
+  >div {
+    height: 100%;
+  }
 }
 
-.optionsList__popoverOverride {
+.timeSlider__popoverOverride {
   width: 100%;
+  max-width: 100%;
   height: 100%;
 }
 
-.timeSlider_anchor {
+.timeSlider__panelOverride {
+  min-width: $euiSizeXXL * 15;
+}
+
+.timeSlider__anchor {
   text-decoration: none;
   width: 100%;
   background-color: $euiFormBackgroundColor;
   box-shadow: none;
   @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right', $internal: true);
+  overflow: hidden;
+  height: 100%;
 
   &:enabled:focus {
     background-color: $euiFormBackgroundColor;
@@ -22,24 +32,11 @@
     background-color: $euiFormBackgroundColor;
   }
 
-  .timeSlider_anchorArrow {
-    padding: $euiSizeM 0;
-  }
-
-  .euiButtonContent {
-    padding: 0;
-  }
-
-  .euiButtonContent,
-  .euiButtonEmpty__text {
-    width: 100%;
-  }
-
-  .timeSlider_anchorText {
+  .timeSlider__anchorText {
     font-weight: $euiFontWeightBold;
   }
 
-  .timeSlider_anchorText__default {
+  .timeSlider__anchorText--default {
     color: $euiColorMediumShade;
   }
 }

--- a/src/plugins/controls/public/control_types/time_slider/time_slider.component.scss
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider.component.scss
@@ -1,7 +1,18 @@
+.optionsList__anchorOverride {
+  display:block;
+}
+
+.optionsList__popoverOverride {
+  width: 100%;
+  height: 100%;
+}
+
 .timeSlider_anchor {
   text-decoration: none;
   width: 100%;
   background-color: $euiFormBackgroundColor;
+  box-shadow: none;
+  @include euiFormControlSideBorderRadius($euiFormControlBorderRadius, $side: 'right', $internal: true);
 
   &:enabled:focus {
     background-color: $euiFormBackgroundColor;
@@ -9,6 +20,14 @@
 
   .euiText {
     background-color: $euiFormBackgroundColor;
+  }
+
+  .timeSlider_anchorArrow {
+    padding: $euiSizeM 0;
+  }
+
+  .euiButtonContent {
+    padding: 0;
   }
 
   .euiButtonContent,

--- a/src/plugins/controls/public/control_types/time_slider/time_slider.component.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider.component.tsx
@@ -7,20 +7,17 @@
  */
 
 import React, { FC, useState, useMemo, useCallback } from 'react';
-import { css } from '@emotion/react';
 import {
-  EuiDualRange,
-  EuiRangeProps,
   EuiDualRangeProps,
   EuiText,
-  EuiFilterButton,
-  EuiFilterGroup,
-  EuiButton,
-  EuiPopover,
+  EuiLoadingSpinner,
+  EuiInputPopover,
   EuiPopoverTitle,
-  EuiFlexGroup,
+  EuiSpacer,
   EuiFlexItem,
-  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiToolTip,
+  EuiButtonIcon,
 } from '@elastic/eui';
 import { EuiRangeTick } from '@elastic/eui/src/components/form/range/range_ticks';
 import moment from 'moment-timezone';
@@ -142,59 +139,48 @@ export const TimeSlider: FC<TimeSliderProps> = (props) => {
       (!isValidRange(range) || (value[1] <= range[1] && value[1] >= range[0]));
 
     valueText = (
-      <EuiFlexGroup gutterSize="none">
-        <EuiFlexItem>
-          <EuiText
-            size="s"
-            className={
-              hasLowerValueInRange ? 'timeSlider_anchorText' : 'timeSlider_anchorText__default'
-            }
-          >
-            {epochToKbnDateFormat(lower)}
-          </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiText className="timeSlider_anchorArrow"> → </EuiText>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText
-            size="s"
-            className={
-              hasUpperValueInRange ? 'timeSlider_anchorText' : 'timeSlider_anchorText__default'
-            }
-          >
-            {epochToKbnDateFormat(upper)}
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiText className="eui-textTruncate" size="s">
+        <span
+          className={
+            hasLowerValueInRange ? 'timeSlider__anchorText' : 'timeSlider__anchorText--default'
+          }
+        >
+          {epochToKbnDateFormat(lower)}
+        </span>
+        &nbsp;&nbsp;→&nbsp;&nbsp;
+        <span
+          className={
+            hasUpperValueInRange ? 'timeSlider__anchorText' : 'timeSlider__anchorText--default'
+          }
+        >
+          {epochToKbnDateFormat(upper)}
+        </span>
+      </EuiText>
     );
   }
 
   const button = (
-    <EuiFilterButton
-      className="timeSlider_anchor"
-      color="text"
-      iconType={'empty'}
-      iconSide="right"
-      isLoading={!hasRange}
-      onClick={togglePopover}
-      isSelected={true}
-    >
+    <button className="timeSlider__anchor eui-textTruncate" color="text" onClick={togglePopover}>
       {valueText}
-    </EuiFilterButton>
+      {!hasRange ? (
+        <div className="timeSliderAnchor__spinner">
+          <EuiLoadingSpinner />
+        </div>
+      ) : undefined}
+    </button>
   );
 
   return (
-    //<EuiFilterGroup style={{ width: '100%', height: '100%' }}>
-    <EuiPopover
-      button={button}
+    <EuiInputPopover
+      input={button}
       isOpen={isPopoverOpen}
-      className="optionsList__popoverOverride"
-      anchorClassName="optionsList__anchorOverride"
+      className="timeSlider__popoverOverride"
+      anchorClassName="timeSlider__anchorOverride"
+      panelClassName="timeSlider__panelOverride"
       closePopover={() => setIsPopoverOpen(false)}
       panelPaddingSize="s"
       anchorPosition="downCenter"
-      ownFocus
+      disableFocusTrap
       repositionOnScroll
     >
       {isValidRange(range) ? (
@@ -202,13 +188,12 @@ export const TimeSlider: FC<TimeSliderProps> = (props) => {
       ) : (
         <TimeSliderComponentPopoverNoDocuments />
       )}
-    </EuiPopover>
-    //</EuiFilterGroup>
+    </EuiInputPopover>
   );
 };
 
 const TimeSliderComponentPopoverNoDocuments: FC = () => {
-  return <EuiText color="default">There were no documents found, so no range is available</EuiText>;
+  return <EuiText size="s">There were no documents found, so no range is available</EuiText>;
 };
 
 export const TimeSliderComponentPopover: FC<TimeSliderProps & { range: [number, number] }> = ({
@@ -234,26 +219,42 @@ export const TimeSliderComponentPopover: FC<TimeSliderProps & { range: [number, 
 
   return (
     <>
-      <EuiPopoverTitle paddingSize="s">
+      <EuiPopoverTitle paddingSize="s">title</EuiPopoverTitle>
+      <EuiText textAlign="center" size="s">
         {epochToKbnDateFormat(lowerValue)} - {epochToKbnDateFormat(upperValue)}
-      </EuiPopoverTitle>
-      <div className="rangeSlider__actions">
-        <ValidatedDualRange
-          id={'my-id'}
-          max={upperBound}
-          min={lowerBound}
-          onChange={onChange}
-          step={undefined}
-          value={[lowerValue, upperValue]}
-          fullWidth
-          ticks={ticks}
-          // levels={levels}
-          showTicks
-          disabled={false}
-          errorMessage={''}
-          allowEmptyRange
-        />
-      </div>
+      </EuiText>
+      <EuiSpacer size="s" />
+      <EuiFlexGroup gutterSize="none">
+        <EuiFlexItem>
+          <ValidatedDualRange
+            id={'my-id'}
+            max={upperBound}
+            min={lowerBound}
+            onChange={onChange}
+            step={undefined}
+            value={[lowerValue, upperValue]}
+            fullWidth
+            ticks={ticks}
+            // levels={levels}
+            showTicks
+            disabled={false}
+            errorMessage={''}
+            allowEmptyRange
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiToolTip content="placeholder content">
+            <EuiButtonIcon
+              iconType="eraser"
+              color="danger"
+              onClick={() => onChange(['', ''])}
+              aria-label="placeholder aria label"
+              data-test-subj="timeSlider__clearRangeButton"
+            />
+          </EuiToolTip>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
     </>
   );
 };

--- a/src/plugins/controls/public/control_types/time_slider/time_slider.component.tsx
+++ b/src/plugins/controls/public/control_types/time_slider/time_slider.component.tsx
@@ -142,26 +142,26 @@ export const TimeSlider: FC<TimeSliderProps> = (props) => {
       (!isValidRange(range) || (value[1] <= range[1] && value[1] >= range[0]));
 
     valueText = (
-      <EuiFlexGroup>
+      <EuiFlexGroup gutterSize="none">
         <EuiFlexItem>
           <EuiText
+            size="s"
             className={
               hasLowerValueInRange ? 'timeSlider_anchorText' : 'timeSlider_anchorText__default'
             }
-            textAlign="right"
           >
             {epochToKbnDateFormat(lower)}
           </EuiText>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiText> → </EuiText>
+          <EuiText className="timeSlider_anchorArrow"> → </EuiText>
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiText
+            size="s"
             className={
               hasUpperValueInRange ? 'timeSlider_anchorText' : 'timeSlider_anchorText__default'
             }
-            textAlign="left"
           >
             {epochToKbnDateFormat(upper)}
           </EuiText>


### PR DESCRIPTION
## Summary

- Added truncation which now works in all control sizes.
- Removed unneeded style code
- Removed **EuiFilterButton** which we don't need and replaced it with a regular button
- Added title to popover (@crob611 this needs to be wired up)
- Moved selected range text into popover body
- Added eraser button to the popover (@crob611 this needs to be wired up too)
- Adjusted text size in anchor
- Replaced **EuiInputPopover** with **EuiPopover** so that the popover width automatically matches the width of the anchor (but set a minimum width for when the anchor gets narrow)

<img width="856" alt="Frame 6" src="https://user-images.githubusercontent.com/4016496/159805960-3470a446-490c-45c8-ac97-671f08af3521.png">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
